### PR TITLE
support of teensy 3.5, 3.6 and improvements under windows

### DIFF
--- a/cmake/Teensy.cmake
+++ b/cmake/Teensy.cmake
@@ -23,51 +23,12 @@
 
 set(TY_EXECUTABLE "/usr/bin/tyc" CACHE FILEPATH "Path to the 'ty' executable that can upload programs to the Teensy")
 
-set(TEENSY_C_CORE_FILES
-    ${TEENSY_ROOT}/math_helper.c
-    ${TEENSY_ROOT}/analog.c
-    ${TEENSY_ROOT}/serial1.c
-    ${TEENSY_ROOT}/serial2.c
-    ${TEENSY_ROOT}/serial3.c
-    ${TEENSY_ROOT}/usb_mem.c
-    ${TEENSY_ROOT}/usb_dev.c
-    ${TEENSY_ROOT}/usb_midi.c
-    ${TEENSY_ROOT}/usb_mouse.c 
-    ${TEENSY_ROOT}/usb_desc.c
-    ${TEENSY_ROOT}/usb_keyboard.c
-    ${TEENSY_ROOT}/usb_joystick.c
-    ${TEENSY_ROOT}/usb_rawhid.c
-    ${TEENSY_ROOT}/usb_seremu.c
-    ${TEENSY_ROOT}/usb_serial.c
-    ${TEENSY_ROOT}/mk20dx128.c
-    ${TEENSY_ROOT}/touch.c
-    ${TEENSY_ROOT}/pins_teensy.c
-    ${TEENSY_ROOT}/keylayouts.c
-    ${TEENSY_ROOT}/nonstd.c
-    ${TEENSY_ROOT}/eeprom.c
-)
+macro(unix_to_windows_path UnixPath ResultingPath)
+  string(REGEX REPLACE "^(/|/cygdrive/)([a-zA-Z])/" "\\2:/" ${ResultingPath} "${UnixPath}")
+endmacro()
 
-set(TEENSY_CXX_CORE_FILES
-    ${TEENSY_ROOT}/main.cpp
-    ${TEENSY_ROOT}/usb_inst.cpp
-    ${TEENSY_ROOT}/yield.cpp
-    ${TEENSY_ROOT}/HardwareSerial1.cpp 
-    ${TEENSY_ROOT}/HardwareSerial2.cpp
-    ${TEENSY_ROOT}/HardwareSerial3.cpp
-    ${TEENSY_ROOT}/WMath.cpp
-    ${TEENSY_ROOT}/Print.cpp
-    
-    ${TEENSY_ROOT}/new.cpp
-    ${TEENSY_ROOT}/usb_flightsim.cpp
-    ${TEENSY_ROOT}/avr_emulation.cpp
-    ${TEENSY_ROOT}/IPAddress.cpp
-    ${TEENSY_ROOT}/Stream.cpp
-    ${TEENSY_ROOT}/Tone.cpp
-    ${TEENSY_ROOT}/IntervalTimer.cpp
-    ${TEENSY_ROOT}/DMAChannel.cpp
-    ${TEENSY_ROOT}/AudioStream.cpp
-    ${TEENSY_ROOT}/WString.cpp
-)
+file(GLOB TEENSY_C_CORE_FILES  "${TEENSY_ROOT}/*.c")
+file(GLOB TEENSY_CXX_CORE_FILES  "${TEENSY_ROOT}/*.cpp")
 
 macro(add_teensy_executable TARGET_NAME SOURCES)
     # Determine the target flags for this executable.
@@ -106,7 +67,13 @@ macro(add_teensy_executable TARGET_NAME SOURCES)
     foreach(SOURCE ${SOURCES})
         get_filename_component(SOURCE_EXT ${SOURCE} EXT)
         get_filename_component(SOURCE_NAME ${SOURCE} NAME_WE)
-        get_filename_component(SOURCE_PATH ${SOURCE} REALPATH)
+        if(CONVERT_PATHS_TO_WIN)
+          get_filename_component(SOURCE_PATH_PRE ${SOURCE} REALPATH)
+          unix_to_windows_path(${SOURCE_PATH_PRE} SOURCE_PATH)
+        else()
+          get_filename_component(SOURCE_PATH ${SOURCE} REALPATH)
+        endif()
+
         if((${SOURCE_EXT} STREQUAL .ino) OR (${SOURCE_EXT} STREQUAL .pde))
             # Generate a stub C++ file from the Arduino sketch file.
             set(GEN_SOURCE "${CMAKE_CURRENT_BINARY_DIR}/${SOURCE_NAME}.cpp")

--- a/cmake/teensy-arm.toolchain.cmake
+++ b/cmake/teensy-arm.toolchain.cmake
@@ -21,20 +21,44 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set(TRIPLE "arm-none-eabi")
+#-------------------------------------------------------------------------------------------------------------------------
+# user-defined settings
+
+set(ARDUINO_ROOT "/usr/share/arduino/")
+#set(TOOLCHAIN_ROOT "${ARDUINO_ROOT}/hardware/tools/arm")
+#note: to make a non-arduino compiler work: copy libarm_*_math.a from ${ARDUINO_ROOT}//hardware/tools/arm/arm-none-eabi/lib to ${TOOLCHAIN_ROOT}/arm-none-eabi/lib
 set(TOOLCHAIN_ROOT "/usr")
-set(TEENSY_CORES_ROOT "/usr/share/arduino/hardware/teensy/cores" CACHE PATH "Path to the Teensy 'cores' repository")
-set(TEENSY_ROOT "${TEENSY_CORES_ROOT}/teensy3")
-set(ARDUINO_LIB_ROOT "/usr/share/arduino/libraries" CACHE PATH "Path to the Arduino library directory")
+set(TEENSY_CORES_ROOT "${ARDUINO_ROOT}/hardware/teensy/avr/cores" CACHE PATH "Path to the Teensy 'cores' repository")
+set(ARDUINO_LIB_ROOT "${ARDUINO_ROOT}/hardware/teensy/avr/libraries" CACHE PATH "Path to the Arduino library directory")
 set(ARDUINO_VERSION "106" CACHE STRING "Version of the Arduino SDK")
 set(TEENSYDUINO_VERSION "120" CACHE STRING "Version of the Teensyduino SDK")
-#set(TEENSY_MODEL "MK20DX256" CACHE STRING "Model of the Teensy MCU")
-set(TEENSY_MODEL "MK20DX256") # XXX Add Teensy 3.0 support.
+set(TEENSY_BOARD "3.6")
 
-set(TEENSY_FREQUENCY "96" CACHE STRING "Frequency of the Teensy MCU (Mhz)")
-set_property(CACHE TEENSY_FREQUENCY PROPERTY STRINGS 96 72 48 24 16 8 4 2)
+#-------------------------------------------------------------------------------------------------------------------------
 
-set(TEENSY_USB_MODE "SERIAL" CACHE STRING "What kind of USB device the Teensy should emulate")
+set(TEENSY_MODEL)
+set(TEENSY_FREQUENCY "0" CACHE STRING "Frequency of the Teensy MCU (Mhz)")
+if(${TEENSY_BOARD} STREQUAL 3.6)
+  set(TEENSY_MODEL "MK66FX1M0")
+  set(TEENSY_FREQUENCY "180")
+  set_property(CACHE TEENSY_FREQUENCY PROPERTY STRINGS 180 168 144 120 96 72 48 24 16 8 4 2)
+elseif(${TEENSY_BOARD} STREQUAL 3.5)
+  set(TEENSY_MODEL "MK64FX512")
+  set(TEENSY_FREQUENCY "120")
+  set_property(CACHE TEENSY_FREQUENCY PROPERTY STRINGS 120 96 72 48 24 16 8 4 2)
+elseif(${TEENSY_BOARD} STREQUAL 3.2)
+  set(TEENSY_MODEL "MK20DX256")
+  set(TEENSY_FREQUENCY "72")
+  set_property(CACHE TEENSY_FREQUENCY PROPERTY STRINGS 96 72 48 24 16 8 4 2)
+elseif(${TEENSY_BOARD} STREQUAL 3.1)
+  set(TEENSY_MODEL "MK20DX128")
+  set(TEENSY_FREQUENCY "72")
+  set_property(CACHE TEENSY_FREQUENCY PROPERTY STRINGS 96 72 48 24 16 8 4 2)
+else()
+  message(FATAL_ERROR "Unknown board model: ${TEENSY_BOARD}")
+endif()
+
+set(TEENSY_USB_MODE "SERIAL_HID" CACHE STRING "What kind of USB device the Teensy should emulate")
 set_property(CACHE TEENSY_USB_MODE PROPERTY STRINGS SERIAL HID SERIAL_HID MIDI RAWHID FLIGHTSIM)
 
 if(WIN32)
@@ -47,25 +71,31 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 set(CMAKE_CROSSCOMPILING 1)
 
+set(TRIPLE "arm-none-eabi")
+
 set(CMAKE_C_COMPILER "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-gcc${TOOL_OS_SUFFIX}" CACHE PATH "gcc" FORCE)
 set(CMAKE_CXX_COMPILER "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-g++${TOOL_OS_SUFFIX}" CACHE PATH "g++" FORCE)
-set(CMAKE_AR "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-ar${TOOL_OS_SUFFIX}" CACHE PATH "archive" FORCE)
+set(CMAKE_AR "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-gcc-ar${TOOL_OS_SUFFIX}" CACHE PATH "archive" FORCE)
 set(CMAKE_LINKER "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-ld${TOOL_OS_SUFFIX}" CACHE PATH "linker" FORCE)
-set(CMAKE_NM "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-nm${TOOL_OS_SUFFIX}" CACHE PATH "nm" FORCE)
+set(CMAKE_NM "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-gcc-nm${TOOL_OS_SUFFIX}" CACHE PATH "nm" FORCE)
 set(CMAKE_OBJCOPY "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-objcopy${TOOL_OS_SUFFIX}" CACHE PATH "objcopy" FORCE)
 set(CMAKE_OBJDUMP "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-objdump${TOOL_OS_SUFFIX}" CACHE PATH "objdump" FORCE)
 set(CMAKE_STRIP "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-strip${TOOL_OS_SUFFIX}" CACHE PATH "strip" FORCE)
-set(CMAKE_RANLIB "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-ranlib${TOOL_OS_SUFFIX}" CACHE PATH "ranlib" FORCE)
+set(CMAKE_RANLIB "${TOOLCHAIN_ROOT}/bin/${TRIPLE}-gcc-ranlib${TOOL_OS_SUFFIX}" CACHE PATH "ranlib" FORCE)
+
+set(TEENSY_ROOT "${TEENSY_CORES_ROOT}/teensy3")
 
 include_directories("${TEENSY_ROOT}")
 
 set(TARGET_FLAGS "-mcpu=cortex-m4 -mthumb")
-set(BASE_FLAGS "-Os -Wall -nostdlib -ffunction-sections -fdata-sections ${TARGET_FLAGS}")
+set(OPT_LEVEL "-Os")
+set(BASE_FLAGS "${OPT_LEVEL} -Wall -nostdlib -ffunction-sections -fdata-sections ${TARGET_FLAGS}")
 
 set(CMAKE_C_FLAGS "${BASE_FLAGS} -DTIME_T=1421620748" CACHE STRING "c flags") # XXX Generate TIME_T dynamically.
-set(CMAKE_CXX_FLAGS "${BASE_FLAGS} -fno-exceptions -fno-rtti -felide-constructors -std=gnu++0x" CACHE STRING "c++ flags")
+set(CMAKE_CXX_FLAGS "${BASE_FLAGS} -fno-exceptions -fno-rtti -felide-constructors -std=gnu++14" CACHE STRING "c++ flags")
 
-set(LINKER_FLAGS "-Os -Wl,--gc-sections ${TARGET_FLAGS} -T${TEENSY_ROOT}/mk20dx256.ld" )
+string(TOLOWER ${TEENSY_MODEL} TEENSY_MODEL_LOWER)
+set(LINKER_FLAGS "${OPT_LEVEL} -Wl,--gc-sections ${TARGET_FLAGS} -T\"${TEENSY_ROOT}/${TEENSY_MODEL_LOWER}.ld\"" )
 set(LINKER_LIBS "-larm_cortexM4l_math -lm" )
 set(CMAKE_SHARED_LINKER_FLAGS "${LINKER_FLAGS}" CACHE STRING "linker flags" FORCE)
 set(CMAKE_MODULE_LINKER_FLAGS "${LINKER_FLAGS}" CACHE STRING "linker flags" FORCE)
@@ -73,7 +103,15 @@ set(CMAKE_EXE_LINKER_FLAGS "${LINKER_FLAGS}" CACHE STRING "linker flags" FORCE)
 
 # Do not pass flags like '-ffunction-sections -fdata-sections' to the linker.
 # This causes undefined symbol errors when linking.
-set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_C_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> -o <TARGET>  <OBJECTS> <LINK_LIBRARIES> ${LINKER_LIBS}" CACHE STRING "Linker command line" FORCE)
+#link with CXX compiler and not C compiler (needed when rtti is enabled, does not change anything otherwise)
+set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> -o <TARGET>  <OBJECTS> <LINK_LIBRARIES> ${LINKER_LIBS}" CACHE STRING "Linker command line" FORCE)
+
+#if using a windows compiler under a unix shell, paths written in template files must be converted to native windows paths
+set(CONVERT_PATHS_TO_WIN FALSE)
+if(${UNIX} AND (NOT DEFINED ${CYGWIN}) AND (NOT DEFINED ${MINGW}))
+  #note: CYGWIN and MINGW are variables, but UNIX seems to be a macro
+  set(CONVERT_PATHS_TO_WIN TRUE)
+endif()
 
 add_definitions("-DARDUINO=${ARDUINO_VERSION}")
 add_definitions("-DTEENSYDUINO=${TEENSYDUINO_VERSION}")

--- a/cmake/teensy-arm.toolchain.cmake
+++ b/cmake/teensy-arm.toolchain.cmake
@@ -58,7 +58,7 @@ else()
   message(FATAL_ERROR "Unknown board model: ${TEENSY_BOARD}")
 endif()
 
-set(TEENSY_USB_MODE "SERIAL_HID" CACHE STRING "What kind of USB device the Teensy should emulate")
+set(TEENSY_USB_MODE "SERIAL" CACHE STRING "What kind of USB device the Teensy should emulate")
 set_property(CACHE TEENSY_USB_MODE PROPERTY STRINGS SERIAL HID SERIAL_HID MIDI RAWHID FLIGHTSIM)
 
 if(WIN32)
@@ -109,7 +109,7 @@ set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK
 #if using a windows compiler under a unix shell, paths written in template files must be converted to native windows paths
 set(CONVERT_PATHS_TO_WIN FALSE)
 if(UNIX)
-  if(NOT DEFINED ${CYGWIN}) AND (NOT DEFINED ${MINGW}))
+  if((NOT DEFINED ${CYGWIN}) AND (NOT DEFINED ${MINGW}))
     #note: CYGWIN and MINGW are variables, but UNIX seems to be a macro
     set(CONVERT_PATHS_TO_WIN TRUE)
   endif()

--- a/cmake/teensy-arm.toolchain.cmake
+++ b/cmake/teensy-arm.toolchain.cmake
@@ -108,9 +108,11 @@ set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK
 
 #if using a windows compiler under a unix shell, paths written in template files must be converted to native windows paths
 set(CONVERT_PATHS_TO_WIN FALSE)
-if(${UNIX} AND (NOT DEFINED ${CYGWIN}) AND (NOT DEFINED ${MINGW}))
-  #note: CYGWIN and MINGW are variables, but UNIX seems to be a macro
-  set(CONVERT_PATHS_TO_WIN TRUE)
+if(UNIX)
+  if(NOT DEFINED ${CYGWIN}) AND (NOT DEFINED ${MINGW}))
+    #note: CYGWIN and MINGW are variables, but UNIX seems to be a macro
+    set(CONVERT_PATHS_TO_WIN TRUE)
+  endif()
 endif()
 
 add_definitions("-DARDUINO=${ARDUINO_VERSION}")


### PR DESCRIPTION
- more definitions to cope with recent teensies
- handling of path format conversions when using a unix shell under windows and the compiler is unaware of unix path syntax.
- auto-discover the list of source files in core lib (the hardcoded list that was included was outdated).